### PR TITLE
Use smaller base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.8-alpine
 
 RUN pip3 install requests PyYAML
 


### PR DESCRIPTION
Use python3.8-alpine as base image for a smaller footprint.