### PR TITLE
Fix unsafe yaml.load

### DIFF
--- a/helper_common.py
+++ b/helper_common.py
@@ -13,7 +13,7 @@ class CommonHelper:
 
     def __init__(self, config_folder):
         self.config_folder = config_folder
-        self.config = yaml.load(open(self.config_folder + 'config.yaml'))
+        self.config = yaml.safe_load(open(self.config_folder + 'config.yaml'))
 
         self.log_level = 2
         if self.config["logs"]["level"] == "debug":

--- a/helper_ha.py
+++ b/helper_ha.py
@@ -7,7 +7,7 @@ import traceback
 class CustomHAHelper:
     def __init__(self, config_folder):
         try:
-            self.config = yaml.load(open(config_folder + 'config.yaml'))
+            self.config = yaml.safe_load(open(config_folder + 'config.yaml'))
             self.base_url = self.config["home_assistant"]["base_url"]
             self.access_token = self.config["home_assistant"]["access_token"]
         except Exception as e:


### PR DESCRIPTION
This change fixes the unsafe yaml.load() method that was deprecated in
PyYAML 6 with yaml.safe_load().