### PR TITLE
Keep retrying read until not pending

### DIFF
--- a/smt_reader.py
+++ b/smt_reader.py
@@ -36,7 +36,7 @@ class SMTReader:
                     auth_token)
 
                 # if an error occured when getting the reading, wait another 5 minutes and then try to get the reading
-                if status_code_read == 1:
+                while status_code_read == 1:
                     self.__commonHelper.log_error(
                         "Still pending, starting another timer for {} minutes".format(str(self.__wait_interval)))
                     time.sleep(self.__wait_interval * 60)


### PR DESCRIPTION
Just started using this project, and I got the following logs:

```
10:05:24.735:debug: Read request response: {"data":{"odrstatus":"PENDING","odrread":"0","odrusage":"0","odrdate":"06/05/2022 05:00:24","responseMessage":"SUCCESS"}}

10:05:24.735:info: Read request is still pending

10:05:24.739:error: Still pending, starting another timer for 5 minutes

10:10:24.827:debug: Starting read of the processed data

/usr/local/lib/python3.8/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'smartmetertexas.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings

  warnings.warn(

10:10:25.240:debug: Read request response: {"data":{"odrstatus":"PENDING","odrread":"0","odrusage":"0","odrdate":"06/05/2022 05:00:24","responseMessage":"SUCCESS"}}

10:10:25.240:info: Read request is still pending

10:10:25.244:info: SMT reading: 

```

So it looks to me like you can get pending for 10+ minutes, therefore this change makes it so it keeps retrying every 5 mins until the status is no longer pending.

---

This could potentially cause issues if SMT never flips this to not-pending, but I'm not sure if that's an actual possibility or not. Maybe a "max times retry" functionality should be added?